### PR TITLE
Fix(#111) - Wrong generic stats category

### DIFF
--- a/storage/storage.js
+++ b/storage/storage.js
@@ -173,9 +173,9 @@ const getTopWebsitesSeries = async (mode = 'co2', number = 3, granularity = 'day
     // sort series
     result.sort((a,b) => b.aggregate - a.aggregate);
 
-    // Add remaing data consumption to 'Divers' category
+    // Add remaing data consumption to 'otherCategory' category
     result.push({
-        name: 'Divers',
+        name: 'otherCategory',
         data: totalPerTimeEntity.map((total, idx) => total - totalPerTimeEntity4TopWebsites[idx])
     });
 

--- a/webpack/src/components/Statistics.vue
+++ b/webpack/src/components/Statistics.vue
@@ -51,8 +51,18 @@ export default {
     const chart = ref(null);
 
     const colors = ['#7D76DE', '#AC84FA', '#8EA3F5', '#76A6DE', '#84DBFA'];
-    const series = ref([]);
+    const rawSeries = ref([]);
     const average = ref(0);
+    
+    const series = computed(() => {
+      return rawSeries.value.map(item => {
+        if (item.name === 'otherCategory') {
+          return { ...item, name: t('components.statistics.otherCategory') };
+        }
+        return item;
+      });
+    });
+    
     const annotation = computed(() => {
       return {
         y: average.value,
@@ -100,6 +110,10 @@ export default {
             t('components.statistics.months.Dec'),
           ];
       }
+    });
+
+    const translatedLabels = computed(() => {
+      
     });
 
     // Should it be dynamic depending on value range?
@@ -251,7 +265,7 @@ export default {
       switch(subtype.value) {
         case 'web':
           getTopWebsitesSeries(type.value, 4, granularity.value).then(async (seriesData: {name: String, data: [number]}[]) => {
-              series.value = seriesData;
+              rawSeries.value = seriesData;
               // update annotation with mean value
               // get number of active periods
               const activePeriods = Array(seriesData[0].data.length).fill(false);
@@ -283,7 +297,7 @@ export default {
           break;
         case 'computer':
           getComputerCo2Series(granularity.value).then((seriesData: {name: String, data: number[]}[]) => {
-              series.value = seriesData;
+              rawSeries.value = seriesData;
               const computer = seriesData[0];
               // update annotation with mean value
               // get number of active period

--- a/webpack/src/components/Statistics.vue
+++ b/webpack/src/components/Statistics.vue
@@ -112,10 +112,6 @@ export default {
       }
     });
 
-    const translatedLabels = computed(() => {
-      
-    });
-
     // Should it be dynamic depending on value range?
     const yAxisCo2 = {
       tickAmount: 3,

--- a/webpack/src/locales/en.json
+++ b/webpack/src/locales/en.json
@@ -74,6 +74,7 @@
       "recommandations": "Recommandations",
       "tips": "Tips on good practices",
       "tip": "Tip",
+      "otherCategory": "Other",
       "days": {
         "Mon": "Mon.",
         "Tue": "Tue.",

--- a/webpack/src/locales/fr.json
+++ b/webpack/src/locales/fr.json
@@ -74,6 +74,7 @@
       "recommandations": "Recommandations",
       "tips": "Recommandations sur les bonnes pratiques",
       "tip": "Recommandation",
+      "otherCategory": "Divers",
       "days": {
         "Mon": "Lun.",
         "Tue": "Mar.",


### PR DESCRIPTION
Symptom:
- The category for "Other" websites in the statistics was incorrectly labeled as "Divers".

Fix:
- The label is now reactive to the selected language:
  - "Other" in English
  - "Divers" in French

Fix #111 